### PR TITLE
Fixed task 3 ("‘M_PI’ was not declared in this scope")

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <algorithm>
 #include <functional>
+#include <cmath>
 
 /**
  * -- TASK 1 --


### PR DESCRIPTION
Task 3 makes use of `M_PI` but `cmath` is not included.
This results in an error: *‘M_PI’ was not declared in this scope.*
Adding the include is supposedly not part of task 3 so this PR fixes the issue.